### PR TITLE
Support Typescript 5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/momentum-trail.js",
       "require": "./dist/momentum-trail.umd.cjs"
     }


### PR DESCRIPTION
With Typescript 5.0 you get this error: 
`ts(7016) error: The library may need to update its package.json or typings`
See 
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing.

This PR fixes the error by adding `types` to the `exports["."]` field.